### PR TITLE
Explicitly specifying a module name for CocoaPods.

### DIFF
--- a/MatchaTea.podspec
+++ b/MatchaTea.podspec
@@ -12,5 +12,6 @@ Pod::Spec.new do |s|
   s.osx.deployment_target       = '10.10'
   s.watchos.deployment_target   = '2.0'
   s.source_files     = 'Matcha/**/*.{h,swift}'
+  s.module_name = 'Matcha'
   s.requires_arc     = true
 end


### PR DESCRIPTION
Matcha's target name in CocoaPods is MatchaTea, which is different from the module name, but this causes an error when used with [cocoapods-binary](https://github.com/leavez/cocoapods-binary).

That is probably a bug in cocoapods-binary, but it would better to specify explicitly because no adversely affected.