### PR TITLE
Update deployment target to 11.0 for ios

### DIFF
--- a/Matcha.xcodeproj/project.pbxproj
+++ b/Matcha.xcodeproj/project.pbxproj
@@ -378,6 +378,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Matcha/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -403,6 +404,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Matcha/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
close #3 

When I tried to build this project with Xcode14.3 (beta3), the build failed because this project does not have a deployment target and is using iOS 8.0, which is no longer supported.
Therefore, the minimum supported version should be set to iOS 11.0.